### PR TITLE
Add support for Joi/Waterline validations block

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,194 @@
 This hook enforces usage of the [Stockade](https://github.com/fpm-git/stockade) module for all Sails actions, providing automagic action patching meant to validate requests against some defined criteria. Where validation criteria are not specified for any given route, that route will always yield in a **403 Forbidden** response being sent to the user, as a strict safety measure.
 
 Reading the [Stockade readme](https://github.com/fpm-git/Stockade/blob/master/README.md) can be quite helpful and is suggested.
+
+# Features
+
+## Stockade permission validation
+
+The primary goal of this hook is to enforce and automatically apply Stockade permission validations in a convenient way. Stockade usage is described quote thoroughly in the [Stockade readme](https://github.com/fpm-git/Stockade/blob/master/README.md). A [dedicated section](https://github.com/fpm-git/Stockade/blob/master/README.md#coupled-with-stockade-hook) exists regarding playing together with this hook.
+
+
+## Action parameter validation
+
+This hook now provides not only convenient Stockade functionality, but also exposes a means of defining automatically executed validations against both Joi and Waterline schema.
+
+Action validation definitions are defined in the same general location as your Stockade permission validations: the Sails `_config` object on each controller. Unlike Stockade permissions though, the presence of parameter validations is not strictly enforced and actions will work fine without them (this is a completely opt-in feature).
+
+### Simple parameter validation
+
+Parameter validations may be defined as simple objects which will be converted to Joi object schema:
+
+```js
+/**
+ * @file UserController.js
+ * Provides actions related to updating and retrieving user data.
+ */
+
+const { Joi, Permissions } = require('stockade-hook');
+
+module.exports = {
+
+    _config: {
+        permissions: {
+            getInfo: Permissions.for('user').allOf('isLoggedIn'),
+        },
+        validations: {
+            getInfo: {
+                userId: Joi.string().hex().length(24).required(),
+            },
+        },
+    },
+
+    async getInfo(req, res) {
+        // ...
+    },
+
+};
+```
+
+The configuration above will ensure that the `getInfo` action has a parameter `userId` which satisfies all of:
+
+  - is a string
+  - is a hexadecimal string
+  - has a length of exactly 24 characters
+
+If any condition above could not be satisfied, the `getInfo` action will not be run and an error will be sent out instead (via `res.badRequest(...)`). If the Floatplane Errors hook is also installed, generated errors will be enriched with additional info and functionality (such as localisation, etc.).
+
+Whenever Joi validations are executed without error, the sanitised result of this validation will be assigned to the `req.validatedParams` property. This allows for accessing any Joi-assigned defaults and avoiding any parameters which were stripped by Joi.
+
+If additional control over the parameters validation schema is required, an already-constructed Joi schema may be passed just as well:
+
+```js
+        validations: {
+            getInfo: Joi.object().keys({
+                userId: Joi.string().hex().length(24).required(),
+            }).unknown(false),
+        },
+```
+
+Simple parameter validation should always be preferred when possible. Some cases where it may not be possible include scenarios where either:
+
+  1. your parameter schema includes a field named example `joi` or `waterline`; or
+  2. more control is required over the source schema itself.
+
+The limitation described by case #1 is brought about by the need for explicit/advanced validators. These are validators defined like so:
+
+```js
+        validations: {
+            getInfo: {
+                joi: {
+                    userId: Joi.string().hex().length(24).required(),
+                },
+                waterline: {
+                    // ...
+                },
+            },
+        },
+```
+
+If stockade-hook ever sees a `joi` or `waterline` top-level validator property, the schema is promoted to an advanced property which may contain not only Joi validations, but Waterline validations as well.
+
+As is demonstrated above, advanced validators accept the same form of Joi schema as simple validators–the only difference is that the schema is now associated with the `joi` property.
+
+
+### Validating against Waterline model attributes
+
+In addition to validating request parameters against Joi schema, it is also possible to perform validations against Waterline model attributes. This can be quite convenient when it's required to accept data which might be used to create or patch some model instance.
+
+In order to validate against Waterline, we must create an advanced validator to inform stockade-hook that we'd like something beyond just simple Joi validation.
+
+Performing validation against some Waterline model might look something like so:
+
+```js
+/**
+ * @file UserController.js
+ * Provides actions related to updating and retrieving user data.
+ */
+
+const { Joi, Permissions } = require('stockade-hook');
+
+module.exports = {
+
+    _config: {
+        permissions: {
+            getInfo: Permissions.for('user').allOf('isLoggedIn'),
+        },
+        validations: {
+            getInfo: {
+                joi: {
+                    username: Joi.string().required(),
+                },
+                waterline: {
+                    username: 'User.username',
+                },
+            },
+        },
+    },
+
+    async getInfo(req, res) {
+        // ...
+    },
+
+};
+```
+
+The schema defined above will ensure that the `username` parameter fully satisfies all Sails model validations defined for the `User.username` attribute. If an invalid value is given, the action will not execute.
+
+Waterline validations may be augmented with usage of either `and` or `or` functionality.
+
+For example, to allow through a value which is either a `User.username` or `User.email`:
+
+```js
+                waterline: {
+                    usernameOrEmail: { or: ['User.username', 'User.email'] },
+                },
+```
+
+Please note that Joi validations will always be executed prior to Waterline validations, and that these Waterline validations might be avoided altogether if the Joi validation phase fails. Additionally, Waterline validations may of course be defined without any `joi` block.
+
+
+### Advanced Joi validation control
+
+By default, stockade-hook does not supply any extra options to the Joi validation function. As a result of this, unknown fields are forbidden, error-checking aborts early after the first error is found, and so on consistent with the Joi defaults.
+
+If refined control over the Joi validation is required, options may be provided by assigning a tuple of form `[schema, options]` for any Joi schema. In this form, `schema` represents a Joi schema as described prior, while `options` represents an object to be passed to the [`Joi.validate`](https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback) call made upon validation.
+
+An example where the early abort default is disabled:
+
+```js
+/**
+ * @file UserController.js
+ * Provides actions related to updating and retrieving user data.
+ */
+
+const { Joi, Permissions } = require('stockade-hook');
+
+module.exports = {
+
+    _config: {
+        permissions: {
+            getInfo: Permissions.for('user').allOf('isLoggedIn'),
+        },
+        validations: {
+            getInfo: {
+                joi: [{
+                    // The usual Joi schema goes here at [0].
+                    username: Joi.string().required(),
+                    include: Joi.array().items(
+                        Joi.string().only('playlists', 'subscriptions'),
+                    ),
+                }, {
+                    // Joi.validate options go here at [1].
+                    abortEarly: false,
+                }],
+            },
+        },
+    },
+
+    async getInfo(req, res) {
+        // ...
+    },
+
+};
+```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 // Classes and fat modules.
+const Joi = require('joi');
 const Permissions = require('stockade');
 const SailsHookStockade = require('./lib/hook');
 
@@ -12,5 +13,6 @@ const declassify = require('./lib/helper/declassify');
 // `declassify` helper to further appease Sails).
 // Additional fields are attached to expose helper functions or classes.
 module.exports = (sails) => declassify(new SailsHookStockade(sails));
+module.exports.Joi = Joi;
 module.exports.Permissions = Permissions;
 module.exports.loadProviders = loadProviders;

--- a/lib/helper/errors.js
+++ b/lib/helper/errors.js
@@ -1,0 +1,43 @@
+
+/**
+ * @todo Provide a simple error service wrapper alongside this, so consumers can transparently
+ * use what may or may not be the Floatplane Errors hook (when the errors hook isn't installed
+ * we can simply emulate basic functionality for it here).
+ */
+
+/**
+ * Used to hold any error service object found to match the appropriate interface expected
+ * from the Floatplane Errors hook. A small optimisation used to avoid repeated checks for
+ * validity.
+ */
+let cacheErrorService = null;
+
+/**
+ * Attempts to fetch something which at least looks like the Floatplane error hook service.
+ * If an appropriate service is found, it will be returned, else `null`.
+ */
+function getErrorService() {
+  // If we're sure there's a proper error service already, simply return that.
+  if (cacheErrorService) {
+    return cacheErrorService;
+  }
+
+  // Try and fetch our global error service.
+  const ErrorService = global.ErrorService;
+  // Ensure the fetched error service matches the expected service interface, returning `null` if not.
+  if (
+    !(ErrorService instanceof Object)
+    || !(ErrorService.isError instanceof Function) || !(ErrorService.isErrorGroup instanceof Function)
+    || !(ErrorService.createError instanceof Function) || !(ErrorService.groupErrors instanceof Function)
+  ) {
+    return null;
+  }
+
+  // We've a good error service present! Set the cached service so we can avoid some checks later on (micro-opt).
+  cacheErrorService = ErrorService;
+  return ErrorService;
+}
+
+module.exports = {
+  tryGetErrorService: getErrorService,
+};

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -144,9 +144,9 @@ module.exports = class SailsHookStockade {
       return res.serverError(RESPONSES.badConfig);
     }
 
-    const marlinConfig = (marlinController && (typeof marlinController === 'object')) ? marlinController._config : {};
-    const marlinPerms = ((marlinConfig && (typeof marlinConfig === 'object')) ? marlinConfig : {}).permissions;
-    const naturalPerms = ((controller && (typeof controller === 'object')) ? controller : {}).permissions;
+    const marlinConfig = ((marlinController instanceof Object) && (marlinController._config instanceof Object)) ? marlinController._config : {};
+    const marlinPerms = marlinConfig.permissions;
+    const naturalPerms = ((controller instanceof Object) ? controller : {}).permissions;
 
     // ensure our `permissions` types are proper objects if they have some truthy value (i.e. they'll not be replaced by an object already)
     if (marlinPerms && (typeof marlinPerms !== 'object')) {

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -1,5 +1,7 @@
 
+// Classes and fat modules.
 const Permissions = require('stockade');
+const ErrorsHelper = require('./helper/errors');
 
 module.exports = class SailsHookStockade {
   constructor(sails) {
@@ -101,10 +103,10 @@ module.exports = class SailsHookStockade {
     // [Normally we wouldn't do this, as having them be plain objects is totally great, they'd be automatically logged and all.]
     // [The exception is being made here simply for clarity purposes, since none of these errors expose anything truly private.]
     // [If this changes and private data is for some reason included in output errors, make sure to remove this conversion.]
-    const hasErrorService = ((global.ErrorService instanceof Object) && (global.ErrorService.createError instanceof Function));
-    if (hasErrorService) {
+    const ErrorService = ErrorsHelper.tryGetErrorService();
+    if (ErrorService) {
       for (const k in RESPONSES) {
-        RESPONSES[k] = global.ErrorService.createError(RESPONSES[k].name, RESPONSES[k].message);
+        RESPONSES[k] = ErrorService.createError(RESPONSES[k].name, RESPONSES[k].message);
       }
     }
 
@@ -185,7 +187,7 @@ module.exports = class SailsHookStockade {
               res.serverError(e);
             }
             // If we've floatplane-hook-error installed, don't bother logging here, as it should handle logging (no double-logging please!).
-            if (global.ErrorService) {
+            if (ErrorService) {
               return;
             }
             return this.sails.log.error('[sails-hook-stockade]', `Error executing action "${fullActionPath}":`, e);
@@ -216,29 +218,31 @@ module.exports = class SailsHookStockade {
  * Stockade.
  */
   _collectFails(failedValidations) {
+    const ErrorService = ErrorsHelper.tryGetErrorService();
+
     if (!Array.isArray(failedValidations)) {
-      return global.ErrorService ? [] : { errors: [] };
+      return ErrorService ? [] : { errors: [] };
     }
 
     // All the different types of error wrappers supported, used as per the `wrapErrors` option.
     const errorWrappers = {
       all(errors) {
-        // If we've no ErrorService with an isError function, simply return the explanations as they are.
-        if (!(global.ErrorService instanceof Object) || !(global.ErrorService.isError instanceof Function)) {
+        // If we've no proper ErrorService, simply return the explanations as they are.
+        if (!ErrorService) {
           return errors;
         }
         // Ensure all errors are wrapped as FloatplaneError objects and return.
         return errors.map(e => {
-          if (global.ErrorService.isError(e)) {
+          if (ErrorService.isError(e)) {
             return e;
           }
-          return global.ErrorService.createError('unknownError', undefined, undefined, e);
+          return ErrorService.createError('unknownError', undefined, undefined, e);
         });
       },
       first(errors) {
-        // If we've an ErrorService with an isError function, try finding a FloatplaneError to take precedence as first.
-        if ((global.ErrorService instanceof Object) && (global.ErrorService.isError instanceof Function)) {
-          const fpError = errors.find(e => global.ErrorService.isError(e));
+        // If we've a proper ErrorService, try finding a FloatplaneError to take precedence as first.
+        if (ErrorService) {
+          const fpError = errors.find(e => ErrorService.isError(e));
           if (fpError) {
             return [fpError];
           }
@@ -247,12 +251,12 @@ module.exports = class SailsHookStockade {
         return this.all(errors.slice(0, 1));
       },
       notLoggedIn(errors) {
-        // If we've no ErrorService with an isError function, then return the explanations as-is.
-        if (!(global.ErrorService instanceof Object) || !(global.ErrorService.isError instanceof Function)) {
+        // If we've no proper ErrorService, then return the explanations as-is.
+        if (!ErrorService) {
           return errors;
         }
         // Try and find our not-logged in error.
-        const notLoggedInError = errors.find(e => global.ErrorService.isError(e) && (e.name === 'notLoggedInError'));
+        const notLoggedInError = errors.find(e => ErrorService.isError(e) && (e.name === 'notLoggedInError'));
         if (notLoggedInError instanceof Object) {
           return [notLoggedInError];
         }
@@ -271,13 +275,13 @@ module.exports = class SailsHookStockade {
     const errors = wrap ? wrap(explanations) : explanations;
 
     // If we've the floatplane-hook-error installed, we should group or return directly any wrapped error.
-    if (wrap && (global.ErrorService instanceof Object) && (global.ErrorService.groupErrors instanceof Function)) {
+    if (wrap && ErrorService) {
       // Catch the case where there somehow are no errors (wot o.o?)
       if (errors.length === 0) {
         return [];
       }
       // If we've one error, return it directly, otherwise return an error group.
-      return (errors.length === 1) ? errors[0] : global.ErrorService.groupErrors(undefined, undefined, errors);
+      return (errors.length === 1) ? errors[0] : ErrorService.groupErrors(undefined, undefined, errors);
     }
     return { errors };
   }

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -3,6 +3,9 @@
 const Permissions = require('stockade');
 const ErrorsHelper = require('./helper/errors');
 
+// Helper functions.
+const requestParamValidator = require('./validations/requestParamValidator');
+
 module.exports = class SailsHookStockade {
   constructor(sails) {
     this.sails = sails;
@@ -87,7 +90,7 @@ module.exports = class SailsHookStockade {
     this.sails._actions[actionName] = wrappedAction;
   }
 
-  _executeActionWrapped(req, res, action) {
+  async _executeActionWrapped(req, res, action) {
     const RESPONSES = {
       malformedAction: {
         name: 'malformedAction',
@@ -169,6 +172,44 @@ module.exports = class SailsHookStockade {
       return res.forbidden(RESPONSES.badConfig);
     }
 
+    // ====================================================
+    // Begin Joi / Waterline params validation
+    // ====================================================
+
+    try {
+      // extract and merge all validations for this controller, if any
+      const marlinValidations = marlinConfig.validations || marlinConfig.params;
+      const naturalValidations = (controller instanceof Object) ? controller.validations || controller.params : {};
+      const allValidations = Object.assign({}, naturalValidations, marlinValidations);
+
+      // Extract any potential schema for the action.
+      const actionSchema = allValidations[actionCaseName];
+
+      // Try and validate our request parameters...
+      // If this succeeds we can simply continue on to validating against Stockade permissions.
+      await requestParamValidator(req, {
+        name: actionCaseName,
+        path: fullActionPath,
+        rawAction: action,
+      }, actionSchema);
+    } catch (paramValidationError) {
+      // Upon error, send out a fitting server error response.
+      // If we've the error service loaded and the error wasn't generated from it, simply throw instead.
+      if (ErrorService && !ErrorService.isError(paramValidationError)) {
+        throw paramValidationError;
+      }
+      // Else send a simple bad request response.
+      return res.badRequest(paramValidationError);
+    }
+
+    // ====================================================
+    // End Joi / Waterline params validation
+    // ====================================================
+
+    // ====================================================
+    // Begin Stockade permission validation
+    // ====================================================
+
     try {
       Permissions.validate(req, matcher).then(validationRes => {
         if (!validationRes.hasPassed) {
@@ -205,6 +246,10 @@ module.exports = class SailsHookStockade {
       this.sails.log.error('[sails-hook-stockade]', 'Error occurred during request validation:', err);
       return res.serverError(err);
     }
+    // ====================================================
+    // End Stockade permission validation
+    // ====================================================
+
   }
 
   /**

--- a/lib/validations/requestParamValidator.js
+++ b/lib/validations/requestParamValidator.js
@@ -1,0 +1,382 @@
+
+/**
+ * @todo This could use a little more cleanup, especially in the Waterline validation portion.
+ * In it's current state, this module was largely just Frankenstein-ed out from the Floatplane
+ * core and made to work with Stockade-hook.
+ */
+
+// Classes and fat modules.
+const Joi = require('joi');
+const ErrorsHelper = require('../helper/errors');
+const util = require('util');
+
+/**
+ * @typedef {Object} SailsActionInfo - Object containing info regarding an invoked Sails
+ * action.
+ * @property {string} actionInfo.name - Name of the action being invoked.
+ * @property {string} actionInfo.path - Full path of the action '/'-delimited.
+ * @property {object} actionInfo.rawAction - Raw action object.
+ */
+
+/**
+ * Performs validation against the given request.
+ *
+ * @param {SailsRequest} req - The original request to run param validation against.
+ *
+ * @param {SailsActionInfo} actionInfo - Information corresponding to the action triggered
+ * to fulfill the given `req`.
+ *
+ * @param {object} schema - Schema to perform validation against. By default it is assumed
+ * that this is a simple object with Joi validations contained. If a top-level `waterline`
+ * property exists, then Waterline validations will be performed against the given object.
+ * It is then expected that any Joi validations exist within a `joi` property.
+ *
+ * @returns Returns `true` if the validation succeeded. If the validation has failed, a fitting
+ * error will be thrown. If the Floatplane errors hook is installed, this error will be wrapped
+ * with the service when possible, else a plain `Error` thrown instead.
+ *
+ * @example ```
+// Simple validation (Joi only):
+validations: {
+  login: {
+    username: Joi.string().required(),
+    password: Joi.string().required(),
+  },
+}
+
+// Advanced validation (both Joi and Waterline):
+validations: {
+  login: {
+    joi: {
+      username: Joi.string().required(),
+      password: Joi.string().required(),
+    },
+    waterline: {
+      username: { or: ['User.username', 'User.email'] },
+    },
+  },
+}
+
+// For any case where a Joi schema is expected, a tuple of form [schema, options] may
+// be supplied instead, containing the Joi schema along with extra options to be used
+// for the validation operation:
+validations: {
+  login: [Joi.object().keys({
+    username: Joi.string().required(),
+    password: Joi.string().required(),
+  }), {
+    abortEarly: false,
+  }],
+}
+
+// Providing Joi advanced options in an advanced (WL+Joi) validator:
+validations: {
+  joi: {
+    login: [Joi.object().keys({
+      username: Joi.string().required(),
+      password: Joi.string().required(),
+    }), {
+      abortEarly: false,
+    }],
+  },
+  waterline: {
+    username: { or: ['User.username', 'User.email'] },
+  },
+}
+
+```
+ *
+ */
+async function validateParams(req, actionInfo, schema) {
+  // Extract our appropriate validators.
+  const { joiSchema, joiSchemaOpts, waterlineSchema } = extractSubschema(schema);
+
+  // If we've a Joi schema, run that validation and update our request with the `validatedParams` field.
+  if (joiSchema) {
+    const validatedParams = testJoiValidations(req, actionInfo, joiSchema, joiSchemaOpts);
+    req.validatedParams = validatedParams;
+  }
+
+  // If we've a Waterline schema, run that validation.
+  if (waterlineSchema) {
+    testWaterlineValidations(req, actionInfo, waterlineSchema);
+  }
+
+  // We've made it here successfully, looks like all validations have passed!
+  return true;
+}
+
+/**
+ * Handles extracting individual Joi and Waterline schema objects from a potentially advanced
+ * schema object.
+ *
+ * @param {object} schema - Schema which should have subschema components extracted. For more
+ * information, refer to the identically named argument belonging to `validateParams(...)`.
+ */
+function extractSubschema(schema) {
+  // Setup our output schema object, with all schema by default `null`-ed out.
+  const out = {
+    joiSchema: null,
+    joiSchemaOpts: null,
+    waterlineSchema: null,
+  };
+
+  // If `schema` isn't an object, there's nothing to validate, so return our `null`-ed schema.
+  if (!(schema instanceof Object)) {
+    return out;
+  }
+
+  // Determine whether or not the validator is an advanced one with potential Waterline support.
+  const isAdvancedValidator = (schema.joi instanceof Object) || (schema.waterline instanceof Object);
+
+  // Helper function which builds Joi schema from either a plain object, tuple, or preconstructed
+  // schema. Joi validation options are also extracted.
+  const extractJoi = (joiSchemaObject) => {
+    // If we've been given a tuple for the schema, extract options and pull the main schema out.
+    if (Array.isArray(joiSchemaObject)) {
+      out.joiSchemaOpts = joiSchemaObject[1];
+      joiSchemaObject = (joiSchemaObject[0] instanceof Object) ? joiSchemaObject[0] : {};
+    }
+
+    // Apply our schema to the output object.
+    out.joiSchema = (joiSchemaObject.isJoi === true)
+      // The given object is already a constructed Joi schema, so we can use it as-is.
+      ? joiSchemaObject
+      // Otherwise we've a plain object given: wrap it as a Joi object.
+      : Joi.object().keys(joiSchemaObject);
+  };
+
+  // Handle extracting schema depending on validator type.
+  if (isAdvancedValidator) {
+    // We've an advanced validator so try and extract from `joi` and `waterline` fields.
+    // Extract any Joi schema as necessary.
+    if (schema.joi instanceof Object) {
+      extractJoi(schema.joi);
+    }
+    // Extract any Waterline schema.
+    if (schema.waterline instanceof Object) {
+      out.waterlineSchema = schema.waterline;
+    }
+  } else {
+    // We've just a simply validator, so take it as a Joi schema.
+    extractJoi(schema);
+  }
+
+  // Return out our object with each potential schema included.
+  return out;
+}
+
+/**
+ * Handles creating an error group for the given Joi validation error, using the Floatplane
+ * error hook. If the error hook is not installed, or if the encountered error could not be
+ * wrapped appropriately, then a plain `Error` is returned instead.
+ *
+ * @param {SailsRequest} req - The request containing the parameters that validation was
+ * performed against.
+ * @param {SailsActionInfo} actionInfo - Information corresponding to the action triggered
+ * to fulfill the given `req`.
+ * @param {ValidationError} joiError - The Joi validation error which we should generate
+ * an error group for.
+ *
+ * @returns {FloatplaneErrorGroup|Error}
+ */
+function makeJoiValidationErrorGroup(req, actionInfo, joiError) {
+  // Generate a prefix for all of our error i18n keys.
+  const errorKeyPrefix = actionInfo.path.replace(/\//g, '.') + '.';
+
+  if (!(joiError instanceof Object) || !Array.isArray(joiError.details)) {
+    return new Error('Received an invalid Joi validation error object. Expected an object with array `details`, but instead found: ' + util.inspect(joiError));
+  }
+
+  // Try and extract the global error service, returning the original Joi error if it's not installed.
+  const ErrorService = ErrorsHelper.tryGetErrorService();
+  if (!ErrorService) {
+    return joiError;
+  }
+
+  const errors = joiError.details.map(info => {
+    const errorKey = errorKeyPrefix + info.context.key + '.' + info.type;
+    // Create a new 'paramValidationError' describing this error, with the broken rule attached.
+    // We'll use the original Joi error message as the default, just in case some language doesn't have the controller-specific error key defined.
+    return ErrorService.createError('paramValidationError', errorKey, undefined, { rule: info.type })
+      .defaultMessage(info.message);
+  });
+
+  return errors.length > 1 ? ErrorService.groupErrors(errors) : errors[0];
+}
+
+/**
+ * Validates the given request's parameters against the provided Joi schema, returning a
+ * plain object with sanitised parameters upon success, or throwing an error upon issue.
+ *
+ * @param {SailsRequest} req - A request containing parameters which should be validated
+ * against the given schema.
+ * @param {SailsActionInfo} actionInfo - Information regarding the action which has been
+ * triggered to fulfill the given `req`.
+ * @param {object} joiSchema - A Joi schema object to validate the given `req` with.
+ * @param {object} [validationOpts] - Optional validation config to supply to Joi.
+ *
+ * @returns {object} Returns parameters sanitised from the given `req` according to the
+ * `joiSchema` passed.
+ *
+ * @throws {FloatplaneErrorGroup|Error} Throws a fitting error if the validation failed
+ * in any way. This error will be wrapped appropriately if the Floatplane error hook is
+ * present, else a plain `Error` returned.
+ */
+function testJoiValidations(req, actionInfo, joiSchema, validationOpts) {
+  const joiResult = Joi.validate(req.allParams(), joiSchema, validationOpts);
+  // If we've an error encountered, wrap appropriately and throw.
+  if (joiResult.error) {
+    throw makeJoiValidationErrorGroup(req, actionInfo, joiResult.error);
+  }
+  // Otherwise all good, simply return the Joi processed result.
+  return joiResult.value;
+}
+
+/**
+ * Handles testing the request parameters for validity against Waterline constraints set
+ * for the attributes corresponding to the given schema.
+ *
+ * @param {SailsRequest} req - A request containing parameters which should be validated
+ * against the given schema.
+ * @param {SailsActionInfo} actionInfo - Information regarding the action which has been
+ * triggered to fulfill the given `req`.
+ * @param {Object} wlSchema - An object defining the validations which should take place
+ * against the given request's parameters.
+ *
+ * @returns {null} Returns `null` after executing without issue, otherwise throws.
+ *
+ * @throws {Error} An error if the schema contains any invalid validation definitions.
+ * @throws {Error} An error if an unhandled error occurred during validation. When this
+ * occurs, please ensure that floatplane-hook-waterline-errors is installed and working!
+ *
+ * @example
+ * // Validates a username parameter against the User model's username attribute definition.
+ * testWaterlineValidations(req, { username: 'User.username' });
+ *
+ * @example
+ * // Ensures that the username parameter is either a valid `email` or `username`, as defined by the User model.
+ * testWaterlineValidations(req, { username: { or: ['User.username', 'User.email'] } })
+ */
+function testWaterlineValidations(req, actionInfo, wlSchema) {
+  // If the schema isn't an object, nothing to check, so no errors. In the future, we may
+  // want to throw if this isn't properly specified.
+  if (!(wlSchema instanceof Object)) {
+    return null;
+  }
+
+  // Initialize our error output array.
+  const errors = [];
+
+  // Loop over all keys in our schema and handle the validation steps.
+  for (const paramName in wlSchema) {
+    // Get the set value for this request, skipping if not set (we only validate defined parameters, use Joi to make them required!).
+    const paramReqValue = req.param(paramName);
+    if (typeof paramReqValue === 'undefined') {
+      continue;
+    }
+
+    // Pull the validation definition from our schema.
+    const paramValidation = wlSchema[paramName];
+
+    // Setup state used for extracting complex definitions from the validation definition object.
+    let validations;
+    let matchAll = false;
+
+    // If the validation is an object, then we may have an {or: ...} or {and: ...} specifier, so handle those.
+    if (paramValidation instanceof Object) {
+      if (Array.isArray(paramValidation.or)) {
+        validations = paramValidation.or;
+      } else if (Array.isArray(paramValidation.and)) {
+        matchAll = true;
+        validations = paramValidation.and;
+      } else {
+        throw new Error(`Invalid Waterline validation specified for action "${actionInfo.path}". Expected an object with key "or" or "and" but instead found: ${util.inspect(paramValidation)}`);
+      }
+    } else if (typeof paramValidation === 'string') {
+      validations = [paramValidation];
+    } else {
+      throw new Error(`Invalid Waterline validation specified for action "${actionInfo.path}". Expected either an object or string, but instead found: ${util.inspect(paramValidation)}`);
+    }
+
+    // Setup an error array to store just the errors for this specific parameter.
+    const paramErrors = [];
+    let failCount = 0;
+
+    // Run all validations on this parameter.
+    validations.forEach(ident => {
+      // Split our identity into fragments and perform consistency checking: [model name, attribute name]
+      const fragments = ident.split('.');
+      if (fragments.length !== 2) {
+        throw new Error(`Invalid Waterline validation specified for parameter "${paramName}" or action "${actionInfo.path}". Expected an attribute identity such as "User.username", but instead found: ${util.inspect(ident)}`);
+      }
+      // Try and find our model, throwing an error if it does not exist.
+      const model = req._sails.models[fragments[0].toLowerCase()];
+      if (!(model instanceof Object) || !(model.validate instanceof Function)) {
+        throw new Error(`Invalid Waterline validation specified for parameter "${paramName}" or action "${actionInfo.path}". The named model "${fragments[0]}" does not exist.`);
+      }
+
+      // Try and run our validation, catching any error, and collecting it if it was generated
+      // from the Floatplane error hook.
+      try {
+        model.validate(fragments[1], paramReqValue);
+      } catch (e) {
+        // If we're missing our error service, throw the error as-is.
+        const ErrorService = ErrorsHelper.tryGetErrorService();
+        if (!ErrorService) {
+          throw e;
+        }
+        // Handle stacking on potential errors from the error hook.
+        if (ErrorService.isError(e)) {
+          paramErrors.push(e);
+          failCount++;
+        } else if (ErrorService.isErrorGroup(e)) {
+          paramErrors.push(...e.errors);
+          failCount++;
+        } else {
+          // Not from the error hook: just throw as-is.
+          throw e;
+        }
+      }
+    });
+
+    // Calculate our minimum required and actual success counts.
+    // When calculating the successCount, it's important to use failCount instead of the
+    // paramErrors.length, as one validation can result in multiple errors being added.
+    const minimumSuccessCount = (matchAll) ? validations.length : 1;
+    const successCount = validations.length - failCount;
+
+    // If we exceed or meet our success count, continue onto the next parameter without adding to the error list.
+    if (successCount >= minimumSuccessCount) {
+      continue;
+    }
+
+    // Otherwise, we've got some errors to add to our list.
+    errors.push(...paramErrors.slice(0, minimumSuccessCount));
+  }
+
+  // If we've no errors: awesome, return null!
+  if (errors.length === 0) {
+    return null;
+  }
+
+  // Handle generating errors where there's no error service.
+  const ErrorService = ErrorsHelper.tryGetErrorService();
+  if (!ErrorService) {
+    // If we've a single error, throw just that.
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    // If we've multiple errors, build a new error to hold all.
+    const err = new Error('Multiple validation errors have occurred!');
+    err.errors = errors;
+    throw err;
+  }
+
+  // Either return a sole error, or make a group out of multiple errors.
+  throw (errors.length === 1)
+    ? errors[0]
+    : ErrorService.groupErrors(undefined, undefined, errors);
+}
+
+module.exports = validateParams;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "hookName": "stockade"
   },
   "dependencies": {
+    "joi": "^14.3.1",
     "stockade": "^1.0.0"
   }
 }


### PR DESCRIPTION
This PR adds support for defining Joi and Waterline validations inside controller `_config` blocks. These validations are automatically run before Stockade permission validations and are completely opt-in functionality.

In-depth information regarding this feature can be seen with the revised README under the "[Action parameter validation](https://github.com/fpm-git/Stockade-hook/blob/ec661c515544516c718183b383eeac1b3bd8ca3c/README.md#action-parameter-validation)" section.

The changes contained within should qualify as a MINOR release going by semver standards: new features have been added, but all prior consumers should function without modifications to existing code.

_Expect this feature to see refinements in the future. Partly Frankenstein effort at the moment._