### PR TITLE
Fix #1: Update `loadProviders` helper to load only .js files

### DIFF
--- a/lib/helper/loadProviders.js
+++ b/lib/helper/loadProviders.js
@@ -2,8 +2,11 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = function loadProviders (pathName) {
-  const entries = fs.readdirSync(pathName);
+module.exports = function loadProviders(pathName) {
+  // Fetch a list of all files inside the requested directory.
+  const entries = fs.readdirSync(pathName)
+    // Filter out the file list to only `.js` files, so we don't try and load some .DS_STORE, etc.
+    .filter(fileName => path.extname(fileName).toLowerCase() === '.js');
 
   entries.forEach(entry => {
     const def = require(path.join(pathName, entry));


### PR DESCRIPTION
This PR has issue #1 fixed by simply changing the helper logic to load only files with the `.js` extension.

It's possible that this may cause issues with certain `require(...)` extensions which add support for additional executable code formats. For exceptional cases like this, I advise compiling Stockade providers to simple `.js` files ahead of time.

(I don't believe the restriction here to be a real potential source of issues, since such loaders already pose problems with Sails)